### PR TITLE
Update index.html

### DIFF
--- a/exponents-and-more/exponents/properties/index.html
+++ b/exponents-and-more/exponents/properties/index.html
@@ -20,7 +20,7 @@
       <title>Properties - Exponents</title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta name="apple-mobile-web-app-title" content="SOCRATHEMATICS">
+      <meta name="apple-mobile-web-app-title" content="YMath">
       <meta name="apple-mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-status-bar-style" content="black">
       <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
@@ -45,7 +45,7 @@ MQ.config({spaceBehavesLikeTab: true,
     return document.createElement('textarea');
   }});
 </script>
-      <link rel="icon" href="https://socrathematics.github.io/favicon.png">
+      <link rel="icon" href="/favicon.png">
       <link rel="stylesheet" href="/fonts.css">
       <link rel="stylesheet" href="/header.css">
       <link rel="stylesheet" href="/style.css">


### PR DESCRIPTION
fixed outdated link, which fixed YMath logo on tab of Exponents >> Properties
